### PR TITLE
fix typo: blogs/urls.py -> blog/urls.py

### DIFF
--- a/django_urls/README.md
+++ b/django_urls/README.md
@@ -70,7 +70,7 @@ urlpatterns = [
 
 ## blog.urls
 
-新しく`blogs/urls.py`という空のファイルを作って下さい。そして最初の2行を以下のように書きます：
+新しく`blog/urls.py`という空のファイルを作って下さい。そして最初の2行を以下のように書きます：
 
 ```
 from django.conf.urls import include, url


### PR DESCRIPTION
Please confirm.

(before)
> 新しく`blogs/urls.py`という空のファイルを作って下さい。

(after)
> 新しく`blog/urls.py`という空のファイルを作って下さい。

(original)
> Create a new empty file named `urls.py` in the `blog` directory.